### PR TITLE
Add @pragma('vm:entry-point') annotations for background handlers and simplify logger setup

### DIFF
--- a/lib/src/plugins/signaling/impl/service/background_message_service.dart
+++ b/lib/src/plugins/signaling/impl/service/background_message_service.dart
@@ -30,6 +30,7 @@ mixin ZegoPluginBackgroundMessageService {
   /// key: 'handler1',
   /// );
   /// ```
+  @pragma('vm:entry-point')
   Future<ZegoSignalingPluginSetMessageHandlerResult>
       setBackgroundMessageHandler(
     ZegoSignalingPluginZPNsBackgroundMessageHandler handler, {
@@ -40,7 +41,8 @@ mixin ZegoPluginBackgroundMessageService {
           key: key,
         );
   }
-
+  
+  @pragma('vm:entry-point')
   Future<ZegoSignalingPluginSetMessageHandlerResult> setThroughMessageHandler(
     ZegoSignalingPluginZPNsThroughMessageHandler? handler,
   ) async {

--- a/lib/src/plugins/signaling/impl/service/invitation_service.dart
+++ b/lib/src/plugins/signaling/impl/service/invitation_service.dart
@@ -251,7 +251,8 @@ mixin ZegoPluginInvitationService {
 
     return ZegoSignalingPluginCore.shared.coreData.reject(invitationID, data);
   }
-
+  
+  @pragma('vm:entry-point')
   Future<ZegoSignalingPluginResponseInvitationResult>
       refuseInvitationByInvitationID({
     required String invitationID,
@@ -333,6 +334,7 @@ mixin ZegoPluginInvitationService {
   }
 
   /// stream callback, notify invitee if invitation timeout
+  @pragma('vm:entry-point')
   Stream<Map<String, dynamic>> getInvitationTimeoutStream() {
     return ZegoSignalingPluginCore
             .shared.coreData.streamCtrlInvitationTimeout?.stream ??
@@ -361,6 +363,7 @@ mixin ZegoPluginInvitationService {
   }
 
   /// stream callback, notify when call invitation cancelled by inviter
+  @pragma('vm:entry-point')
   Stream<Map<String, dynamic>> getInvitationCanceledStream() {
     return ZegoSignalingPluginCore
             .shared.coreData.streamCtrlInvitationCanceled?.stream ??

--- a/lib/src/plugins/signaling/impl/service/invitation_service_advance.dart
+++ b/lib/src/plugins/signaling/impl/service/invitation_service_advance.dart
@@ -676,6 +676,7 @@ mixin ZegoPluginInvitationServiceAdvance {
   }
 
   /// stream callback, notify invitee if invitation timeout
+  @pragma('vm:entry-point')
   Stream<Map<String, dynamic>> getAdvanceInvitationTimeoutStream() {
     return ZegoSignalingPluginCore
             .shared.coreData.streamCtrlAdvanceInvitationTimeout?.stream ??
@@ -683,6 +684,7 @@ mixin ZegoPluginInvitationServiceAdvance {
   }
 
   /// stream callback, notify when call invitation cancelled by inviter
+  @pragma('vm:entry-point')
   Stream<Map<String, dynamic>> getAdvanceInvitationCanceledStream() {
     return ZegoSignalingPluginCore
             .shared.coreData.streamCtrlAdvanceInvitationCanceled?.stream ??

--- a/lib/src/services/channel_service.dart
+++ b/lib/src/services/channel_service.dart
@@ -17,6 +17,7 @@ mixin ZegoChannelService {
     return ZegoUIKitPluginPlatform.instance.checkAppRunning();
   }
 
+  @pragma('vm:entry-point')
   Future<void> activeAppToForeground() async {
     await ZegoUIKitPluginPlatform.instance.activeAppToForeground();
   }
@@ -87,6 +88,7 @@ mixin ZegoChannelService {
     await ZegoUIKitPluginPlatform.instance.enableCustomVideoRender(isEnabled);
   }
 
+  @pragma('vm:entry-point')
   Future<void> requestDismissKeyguard() async {
     await ZegoUIKitPluginPlatform.instance.requestDismissKeyguard();
   }

--- a/lib/src/services/logger_service.dart
+++ b/lib/src/services/logger_service.dart
@@ -48,6 +48,7 @@ mixin ZegoLoggerService {
     FlutterLogs.clearLogs();
   }
 
+  @pragma('vm:entry-point')
   static Future<void> logInfo(
     String logMessage, {
     String tag = '',

--- a/lib/src/services/logger_service.dart
+++ b/lib/src/services/logger_service.dart
@@ -15,12 +15,7 @@ mixin ZegoLoggerService {
 
     try {
       await FlutterLogs.initLogs(
-              logLevelsEnabled: [
-                LogLevel.INFO,
-                LogLevel.WARNING,
-                LogLevel.ERROR,
-                LogLevel.SEVERE
-              ],
+              logLevelsEnabled: [LogLevel.INFO, LogLevel.WARNING, LogLevel.ERROR, LogLevel.SEVERE],
               timeStampFormat: TimeStampFormat.TIME_FORMAT_24_FULL,
               directoryStructure: DirectoryStructure.SINGLE_FILE_FOR_DAY,
               logTypesEnabled: ['device', 'network', 'errors'],

--- a/lib/src/services/plugin_service.dart
+++ b/lib/src/services/plugin_service.dart
@@ -28,6 +28,7 @@ mixin ZegoPluginService {
   }
 
   /// signal plugin
+  @pragma('vm:entry-point')
   ZegoUIKitSignalingPluginImpl getSignalingPlugin() {
     /// make sure core data's stream had created
     ZegoSignalingPluginCore.shared.coreData.initData();


### PR DESCRIPTION
**💡 Why This Change Matters:**
* @pragma('vm:entry-point') ensures that Dart’s tree shaker doesn’t remove these methods when your app is compiled, especially important for background isolates and callbacks (like push or callkit-related ones).
* This allows background methods to be invoked correctly even when they’re not directly referenced in the main code path.


This PR adds @pragma('vm:entry-point') to critical background methods and streams to ensure they're retained during tree shaking, especially useful for push/background messaging scenarios.
Also refactors logger_service.dart by simplifying the initLogs call to directly pass logLevelsEnabled without redundant formatting.