### PR TITLE
feat: add audio 3A configuration APIs

### DIFF
--- a/lib/src/services/audio_video_service.dart
+++ b/lib/src/services/audio_video_service.dart
@@ -106,10 +106,6 @@ mixin ZegoAudioVideoService {
   void enableANS(bool enable) {
     ZegoUIKitCore.shared.enableANS(enable);
   }
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.enableANS(enable);
-  }
 
   /// Audio 3A - Enable/disable transient noise suppression
   ///

--- a/lib/src/services/audio_video_service.dart
+++ b/lib/src/services/audio_video_service.dart
@@ -54,6 +54,114 @@ mixin ZegoAudioVideoService {
     await ZegoUIKitCore.shared.setAudioConfig(config, streamType: streamType);
   }
 
+  /// Audio 3A - Enable/disable echo cancellation (AEC)
+  ///
+  /// After calling this method, the SDK will no longer automatically determine whether to enable echo cancellation.
+  ///
+  /// Call this method at: After joining a room
+  ///
+  /// @param enable true to enable echo cancellation, false to disable
+  void enableAEC(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable AEC: $enable',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.enableAEC(enable);
+  }
+
+  /// Audio 3A - Enable/disable echo cancellation when using headphones
+  ///
+  /// Recommended for voice chat and gaming scenarios.
+  ///
+  /// Call this method at: After joining a room
+  ///
+  /// @param enable true to enable headphone AEC, false to disable (default)
+  void enableHeadphoneAEC(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable headphone AEC: $enable',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.enableHeadphoneAEC(enable);
+  }
+
+  /// Audio 3A - Set echo cancellation mode
+  ///
+  /// Call this method at: After enabling AEC (enableAEC(true))
+  ///
+  /// @param mode AEC mode: Aggressive, Medium, or Soft
+  void setAECMode(ZegoAECMode mode) {
+    ZegoLoggerService.logInfo(
+      'set AEC mode: $mode',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.setAECMode(mode);
+  }
+
+  /// Audio 3A - Enable/disable automatic gain control (AGC)
+  ///
+  /// Recommended to disable in music scenarios.
+  ///
+  /// Call this method at: After joining a room
+  ///
+  /// @param enable true to enable AGC, false to disable
+  void enableAGC(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable AGC: $enable',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.enableAGC(enable);
+  }
+
+  /// Audio 3A - Enable/disable noise suppression (ANS)
+  ///
+  /// Helps make voice clearer.
+  ///
+  /// Call this method at: After joining a room
+  ///
+  /// @param enable true to enable ANS, false to disable
+  void enableANS(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable ANS: $enable',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.enableANS(enable);
+  }
+
+  /// Audio 3A - Enable/disable transient noise suppression
+  ///
+  /// Helps suppress transient noises such as keyboard typing and tapping.
+  ///
+  /// Call this method at: After joining a room
+  ///
+  /// @param enable true to enable transient ANS, false to disable (default)
+  void enableTransientANS(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable transient ANS: $enable',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.enableTransientANS(enable);
+  }
+
+  /// Audio 3A - Set noise suppression mode
+  ///
+  /// Call this method at: After enabling ANS (enableANS(true))
+  ///
+  /// @param mode ANS mode: Aggressive, Medium (default), or Soft
+  void setANSMode(ZegoANSMode mode) {
+    ZegoLoggerService.logInfo(
+      'set ANS mode: $mode',
+      tag: 'uikit',
+      subTag: 'audio video service',
+    );
+    ZegoExpressEngine.instance.setANSMode(mode);
+  }
+
   /// update video config
   Future<void> setVideoConfig(
     ZegoUIKitVideoConfig config, {

--- a/lib/src/services/audio_video_service.dart
+++ b/lib/src/services/audio_video_service.dart
@@ -62,12 +62,7 @@ mixin ZegoAudioVideoService {
   ///
   /// @param enable true to enable echo cancellation, false to disable
   void enableAEC(bool enable) {
-    ZegoLoggerService.logInfo(
-      'enable AEC: $enable',
-      tag: 'uikit',
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.enableAEC(enable);
+    ZegoUIKitCore.shared.enableAEC(enable);
   }
 
   /// Audio 3A - Enable/disable echo cancellation when using headphones
@@ -78,12 +73,7 @@ mixin ZegoAudioVideoService {
   ///
   /// @param enable true to enable headphone AEC, false to disable (default)
   void enableHeadphoneAEC(bool enable) {
-    ZegoLoggerService.logInfo(
-      'enable headphone AEC: $enable',
-      tag: 'uikit',
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.enableHeadphoneAEC(enable);
+    ZegoUIKitCore.shared.enableHeadphoneAEC(enable);
   }
 
   /// Audio 3A - Set echo cancellation mode
@@ -92,12 +82,7 @@ mixin ZegoAudioVideoService {
   ///
   /// @param mode AEC mode: Aggressive, Medium, or Soft
   void setAECMode(ZegoAECMode mode) {
-    ZegoLoggerService.logInfo(
-      'set AEC mode: $mode',
-      tag: 'uikit',
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.setAECMode(mode);
+    ZegoUIKitCore.shared.setAECMode(mode);
   }
 
   /// Audio 3A - Enable/disable automatic gain control (AGC)
@@ -108,12 +93,7 @@ mixin ZegoAudioVideoService {
   ///
   /// @param enable true to enable AGC, false to disable
   void enableAGC(bool enable) {
-    ZegoLoggerService.logInfo(
-      'enable AGC: $enable',
-      tag: 'uikit',
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.enableAGC(enable);
+    ZegoUIKitCore.shared.enableAGC(enable);
   }
 
   /// Audio 3A - Enable/disable noise suppression (ANS)
@@ -124,9 +104,8 @@ mixin ZegoAudioVideoService {
   ///
   /// @param enable true to enable ANS, false to disable
   void enableANS(bool enable) {
-    ZegoLoggerService.logInfo(
-      'enable ANS: $enable',
-      tag: 'uikit',
+    ZegoUIKitCore.shared.enableANS(enable);
+  }
       subTag: 'audio video service',
     );
     ZegoExpressEngine.instance.enableANS(enable);
@@ -140,12 +119,7 @@ mixin ZegoAudioVideoService {
   ///
   /// @param enable true to enable transient ANS, false to disable (default)
   void enableTransientANS(bool enable) {
-    ZegoLoggerService.logInfo(
-      'enable transient ANS: $enable',
-      tag: 'uikit',
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.enableTransientANS(enable);
+    ZegoUIKitCore.shared.enableTransientANS(enable);
   }
 
   /// Audio 3A - Set noise suppression mode
@@ -154,12 +128,7 @@ mixin ZegoAudioVideoService {
   ///
   /// @param mode ANS mode: Aggressive, Medium (default), or Soft
   void setANSMode(ZegoANSMode mode) {
-    ZegoLoggerService.logInfo(
-      'set ANS mode: $mode',
-      tag: 'uikit',
-      subTag: 'audio video service',
-    );
-    ZegoExpressEngine.instance.setANSMode(mode);
+    ZegoUIKitCore.shared.setANSMode(mode);
   }
 
   /// update video config

--- a/lib/src/services/internal/core/core.dart
+++ b/lib/src/services/internal/core/core.dart
@@ -1270,6 +1270,76 @@ class ZegoUIKitCore
     coreData.channelAudioConfig[streamType] = config;
   }
 
+  /// Audio 3A - Enable/disable echo cancellation (AEC)
+  void enableAEC(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable:$enable',
+      tag: 'uikit-audio',
+      subTag: 'enable AEC',
+    );
+    ZegoExpressEngine.instance.enableAEC(enable);
+  }
+
+  /// Audio 3A - Enable/disable echo cancellation when using headphones
+  void enableHeadphoneAEC(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable:$enable',
+      tag: 'uikit-audio',
+      subTag: 'enable headphone AEC',
+    );
+    ZegoExpressEngine.instance.enableHeadphoneAEC(enable);
+  }
+
+  /// Audio 3A - Set echo cancellation mode
+  void setAECMode(ZegoAECMode mode) {
+    ZegoLoggerService.logInfo(
+      'mode:$mode',
+      tag: 'uikit-audio',
+      subTag: 'set AEC mode',
+    );
+    ZegoExpressEngine.instance.setAECMode(mode);
+  }
+
+  /// Audio 3A - Enable/disable automatic gain control (AGC)
+  void enableAGC(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable:$enable',
+      tag: 'uikit-audio',
+      subTag: 'enable AGC',
+    );
+    ZegoExpressEngine.instance.enableAGC(enable);
+  }
+
+  /// Audio 3A - Enable/disable noise suppression (ANS)
+  void enableANS(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable:$enable',
+      tag: 'uikit-audio',
+      subTag: 'enable ANS',
+    );
+    ZegoExpressEngine.instance.enableANS(enable);
+  }
+
+  /// Audio 3A - Enable/disable transient noise suppression
+  void enableTransientANS(bool enable) {
+    ZegoLoggerService.logInfo(
+      'enable:$enable',
+      tag: 'uikit-audio',
+      subTag: 'enable transient ANS',
+    );
+    ZegoExpressEngine.instance.enableTransientANS(enable);
+  }
+
+  /// Audio 3A - Set noise suppression mode
+  void setANSMode(ZegoANSMode mode) {
+    ZegoLoggerService.logInfo(
+      'mode:$mode',
+      tag: 'uikit-audio',
+      subTag: 'set ANS mode',
+    );
+    ZegoExpressEngine.instance.setANSMode(mode);
+  }
+
   Future<void> setVideoConfig(
     ZegoUIKitVideoConfig config,
     ZegoStreamType streamType,


### PR DESCRIPTION
## Summary\nAdd audio 3A (AEC, AGC, ANS) configuration APIs to ZegoUIKitCore with logging support.\n\n## Changes\n- Add enableAEC, enableHeadphoneAEC, setAECMode for Acoustic Echo Cancellation\n- Add enableAGC for Automatic Gain Control\n- Add enableANS, enableTransientANS, setANSMode for Automatic Noise Suppression\n\n## Commits\n- feat: add audio 3A configuration APIs with logging\n- refactor: follow existing code conventions - add audio 3A methods in ZegoUIKitCore\n- fix: remove leftover code from audio_video_service.dart\n\n## Testing\nTested locally on iOS and Android platforms.